### PR TITLE
Fix a typo in vtkhandler.py

### DIFF
--- a/smithers/io/vtkhandler.py
+++ b/smithers/io/vtkhandler.py
@@ -18,7 +18,7 @@ class VTKHandler(BaseVTKHandler):
         reader = cls._reader_()
         reader.SetFileName(filename)
         reader.Update()
-        return parse(reader.GetOutput())
+        return cls.parse(reader.GetOutput())
 
     @classmethod
     def parse(cls, data):


### PR DESCRIPTION
Use `cls.parse` instead of `parse`.
Without this fix, python throws the following error: name 'parse' is not defined