### PR TITLE
New feature: progress bar. Bug fixed in openfoamhandler

### DIFF
--- a/smithers/io/openfoam/openfoamhandler.py
+++ b/smithers/io/openfoam/openfoamhandler.py
@@ -1,19 +1,16 @@
 import Ofpp
 import os
 import numpy as np
-import matplotlib.pyplot as plt
-from operator import itemgetter
 from .openfoamutils import polyarea, project, Parser, read_mesh_file
-
 
 def progress(count, total):
     bar_len = 70
-    filled_len = int(round(bar_len * count / float(total)))
+    filled_len = int(round(bar_len*count/float(total)))
 
-    percents = round(100.0 * count / float(total), 1)
-    bar = '#' * filled_len + '-' * (bar_len - filled_len)
+    percents = round(100.0*count/float(total), 1)
+    bar = '#'*filled_len + '-'*(bar_len - filled_len)
 
-    print('\r[%s] %s%s' % (bar, percents, '%'), end = '', flush = True)
+    print('\r[{}] {} {}'.format(bar, percents, '%'), end = '', flush = True)
 
 class OpenFoamHandler:
     """
@@ -216,7 +213,6 @@ class OpenFoamHandler:
         # if `fields_time_instants` is a list of strings, we take only the
         # subfolders whose name exactly matches with the strings in the list.
         elif isinstance(fields_time_instants, list):
-            fields_time_instants = [str(x) for x in fields_time_instants]
             return list(map(full_path_with_label, fields_time_instants))
         else:
             raise ValueError(
@@ -449,20 +445,14 @@ class OpenFoamHandler:
             filename, time_instants
         )
         if time_instants is not None:
-            count = 0
-            tmp = dict()
+            out = dict()
             print('Snapshot acqusition in progress...')
-            for name, path in time_instants:
-                count += 1
+            for count, (name, path) in enumerate(time_instants, 1):
                 progress(count, len(time_instants))
-                tmp = (
-                    name,
-                    cls._build_time_instant_snapshot(
-                        ofpp_mesh, path, field_names, traveling_mesh
-                    ),
-                )
+                out[name] = cls._build_time_instant_snapshot(
+                    ofpp_mesh, path, field_names, traveling_mesh)
             print()
-            return tmp
+            return out
         else:
             return cls._build_time_instant_snapshot(
                 ofpp_mesh, filename, field_names, traveling_mesh

--- a/smithers/io/openfoam/openfoamhandler.py
+++ b/smithers/io/openfoam/openfoamhandler.py
@@ -1,6 +1,5 @@
 import Ofpp
 import os
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from operator import itemgetter
@@ -8,14 +7,13 @@ from .openfoamutils import polyarea, project, Parser, read_mesh_file
 
 
 def progress(count, total):
-    bar_len = 100
+    bar_len = 70
     filled_len = int(round(bar_len * count / float(total)))
 
     percents = round(100.0 * count / float(total), 1)
     bar = '#' * filled_len + '-' * (bar_len - filled_len)
 
-    sys.stdout.write('[%s] %s%s\r' % (bar, percents, '%'))
-    sys.stdout.flush()
+    print('\r[%s] %s%s' % (bar, percents, '%'), end = '', flush = True)
 
 class OpenFoamHandler:
     """
@@ -463,9 +461,9 @@ class OpenFoamHandler:
                         ofpp_mesh, path, field_names, traveling_mesh
                     ),
                 )
+            print()
             return tmp
         else:
             return cls._build_time_instant_snapshot(
                 ofpp_mesh, filename, field_names, traveling_mesh
             )
-            

--- a/smithers/io/openfoam/openfoamhandler.py
+++ b/smithers/io/openfoam/openfoamhandler.py
@@ -468,3 +468,4 @@ class OpenFoamHandler:
             return cls._build_time_instant_snapshot(
                 ofpp_mesh, filename, field_names, traveling_mesh
             )
+            


### PR DESCRIPTION
In openfoamhandler.py, there was an issue when building paths for time instants subfolders: it is necessary to convert the assigned list of integers containing the time instants to a list of strings. Otherwise the join method returns an error.

I added a method defining a progress bar outside the class OpenFoamHandler in openfoamhandler.py in order to monitor the progress of the snapshot acquisition (useful when dealing with hundreds or thousands snapshots).

At line 216 the method should return a list of maps, not a map (?!) I am not 100% sure about this but I modified it. Please, give me a feedback about that.