### PR TITLE
Fixed parsing of boundary patches from binary format

### DIFF
--- a/smithers/io/openfoam/field_parser.py
+++ b/smithers/io/openfoam/field_parser.py
@@ -172,7 +172,7 @@ def split_boundary_content(content):
             if lc.rstrip() == b'}':
                 break
             if in_patch_field:
-                if lc.strip() == b'}':
+                if lc.strip(b' \t\n') == b'}' and content[n-1].endswith(b');\n'):
                     bd[current_path][1] = n-1
                     in_patch_field = False
                     current_path = ''


### PR DESCRIPTION
Since the end of boundary patches in binary file was checked by stripping the line and checking if the result was equal to '}' it was possible that the end of a patch was miss-detected, since a '}' surrounded by characters that are removed by the strip function could appear randomly in the binary content (and indeed happened in my case ).

I updated the check to remove only withe spaces, tabs and new lines in the stripping operation and check for the ');' characters at the end of the previous line to determine if the actual end of the boundary patch is reached.

I think its theoretically possible that the end of a patch is still miss-detected (since a ');' followed on the next line by a '}' surrounded by tabs or withe-spaces could still appear randomly in the binary content) but it's much more unlikely.